### PR TITLE
Support url override in filter config

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,37 @@ or to send all but the `loaded_scripts` log:
 ```
 redef LogZsonHttp::exclude_logs = set(LoadedScripts::LOG);
 ```
+
+#### Sending logs to different endpoints
+
+The `LogZsonHttp::url` endpoint can be overridden on a per-log basis
+by instantiating a `Log::Filter` and passing the url in its
+configuration table. For example: 
+
+```
+@load Zeek/ZsonHttp
+
+# Set this to the URL of your HTTP endpoint
+redef LogZsonHttp::url = "http://localhost:9867/some/endpoint";
+
+event bro_init() &priority=-10
+{
+    # handles HTTP
+    local http_filter: Log::Filter = [
+        $name = "zson-http",
+        $writer = Log::WRITER_ZSONHTTP,
+        $path = "http",
+        $config = table(["url"] = "http://localhost:9877/other/endpoint")
+    ];
+    Log::add_filter(HTTP::LOG, http_filter);
+
+    # handles DNS
+    local dns_filter: Log::Filter = [
+        $name = "zson-dns",
+        $writer = Log::WRITER_ZSONHTTP,
+        $path = "dns",
+        $config = table(["url"] = "http://localhost:9887/and/another/endpoint")
+    ];
+    Log::add_filter(DNS::LOG, dns_filter);
+}
+```

--- a/src/ZsonHttp.cc
+++ b/src/ZsonHttp.cc
@@ -30,8 +30,25 @@ ZsonHttp::ZsonHttp(WriterFrontend* frontend) : WriterBackend(frontend)
     databuf2.Clear();
     headerbuf.Clear();
     connstate = CLOSED;
+    InitConfigOptions();
+    InitFilterOptions();
 }
 
+void ZsonHttp::InitConfigOptions()
+{
+    endpoint = BifConst::LogZsonHttp::url->AsString()->CheckString();
+}
+
+void ZsonHttp::InitFilterOptions()
+{
+	const WriterInfo& info = Info();
+
+	for ( WriterInfo::config_map::const_iterator i = info.config.begin(); i != info.config.end(); ++i ) {
+            if ( strcmp(i->first, "url") == 0 ) {
+                endpoint = i->second;
+            }
+        }
+}
 
 bool ZsonHttp::InitFormatter()
 {
@@ -104,7 +121,6 @@ bool ZsonHttp::CurlConnect()
 void ZsonHttp::CurlSetopts()
 {
 
-    string endpoint = BifConst::LogZsonHttp::url->AsString()->CheckString();
 
     PLUGIN_DBG_LOG(plugin::Zeek_ZsonHttp::plugin, "Endpoint: %s", endpoint.c_str());
     curl_easy_setopt(curl, CURLOPT_URL, endpoint.c_str());

--- a/src/ZsonHttp.h
+++ b/src/ZsonHttp.h
@@ -44,6 +44,9 @@ namespace logging { namespace writer {
             };
             int connstate;
 
+            void InitConfigOptions();
+            void InitFilterOptions();
+
             void WriteHeader(const string& path);
             void WriteHeaderField(const string& key, const string& value);
             string Timestamp(double t); // Uses current time if t is zero.
@@ -74,6 +77,7 @@ namespace logging { namespace writer {
             const string unset_field = "-";
             const string meta_prefix = "#";
 
+            string endpoint;
             string path;
 
             threading::formatter::Formatter* formatter;


### PR DESCRIPTION
Fixes #1. 

As per the README, this change allows the URL to be overridden on a per-log basis, for example:

```
event bro_init() &priority=-10
{
    local http_filter: Log::Filter = [
        $name = "zson-http",
        $writer = Log::WRITER_ZSONHTTP,
        $path = "http",
        $config = table(["url"] = "http://localhost:9877/other/endpoint")
    ];
    Log::add_filter(HTTP::LOG, http_filter);

    local dns_filter: Log::Filter = [
        $name = "zson-dns",
        $writer = Log::WRITER_ZSONHTTP,
        $path = "dns",
        $config = table(["url"] = "http://localhost:9887/and/another/endpoint")
    ];
    Log::add_filter(DNS::LOG, dns_filter);
}
```